### PR TITLE
grid 페이지 표시 에러로 max-width 임시적용

### DIFF
--- a/src/pages/grid_page/GridMemo.tsx
+++ b/src/pages/grid_page/GridMemo.tsx
@@ -86,6 +86,7 @@ const GridText = styled(Text)`
   border-bottom: 0.5px solid rgba(0, 0, 0, 0.2);
   line-height: 1.375rem;
 
+  max-width: 22vh; /*  예기치못한 에러로 임시 지정값 */
   ${setTextLine};
 `
 

--- a/src/pages/grid_page/GridPage.tsx
+++ b/src/pages/grid_page/GridPage.tsx
@@ -68,5 +68,5 @@ const GridBox = styled.div`
   gap: .5rem;
   padding: .5rem;
   overflow-y: scroll ;
-`
 
+`

--- a/src/styles/stylesCss.ts
+++ b/src/styles/stylesCss.ts
@@ -74,6 +74,9 @@ export const setTextLine = css<{whiteSpace?: string, lineClamp?: number}>`
   overflow: hidden;
   -webkit-line-clamp: ${({lineClamp}) => lineClamp ? lineClamp : 1  };;
   -webkit-box-orient: vertical;
+
+  ${overFlowHidden};
+
   text-overflow: ellipsis;
   white-space: ${({whiteSpace}) => whiteSpace ? whiteSpace : 'pre-wrap'  };
 `


### PR DESCRIPTION
- grid 페이지 grid template이 오류나면서 임시로 하위 요소의 최댓값을 적용시킴
- 여러 요소 중, 가장 크로스 브라우징 이슈가 적으면서 어색함이 적은 요소로, vh적용
- 오류 원인은 GridText 요소가 넘침에 따라 깨지는 것 같으나, 왜 깨지는지는 아직 파악 불가