### PR TITLE
메모 불러오기 오류수정, 로드 메모 갯수 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,14 +52,12 @@ const App = ({ fbAuth, fbTag, fbMemo }: IApp) => {
 
   // 메모 로그인시 설정 초기화
   const initAppLogin = async (user: User) => {
-    // loading.start();
     const paletteObj = await fbAuth.getPalette(); // 팔레트 설정
     palette.setPalette(paletteObj);
     fbAuth.setUid(user); // uid 의존성 주입
     fbTag.setDoc(user); // uid 의존성 주입
     fbMemo.setDoc(user); // uid 의존성 주입
 
-    // loading.finish();
     fbTag.onCheckTag(setTags); // 태그정보 실시간체크
     fbAuth.onCheckUserInfo(setUserInfo); // UserDB 정보 실시간체크
     navigate("/talk", { replace: true });

--- a/src/firebase/firestore_memo_service.ts
+++ b/src/firebase/firestore_memo_service.ts
@@ -35,7 +35,7 @@ export class FbMemo {
     this.fireStoreDB = fireStoreDB;
     this.doc = "default";
     this.lastMemo = null;
-    this.loadSize = 50;
+    this.loadSize = 30;
   }
 
   initLastMemo() {
@@ -111,7 +111,7 @@ export class FbMemo {
     try {
       const querySnapshot = await getDocs(q);
       const result = querySnapshot.docs.map(doc => doc.data() as IMemo);
-
+      console.log("불러올 메모 확인", result)
       if (result === []) this.lastMemo = undefined;
       // 결과지정. 더 불러올 메모가 없으면 undefined로 변경
       else this.lastMemo = querySnapshot.docs[querySnapshot.docs.length - 1];

--- a/src/pages/talk_page/TalkPage.tsx
+++ b/src/pages/talk_page/TalkPage.tsx
@@ -68,7 +68,6 @@ const TalkPage = ({ fbMemo, fbTag, fbAuth, tags, userInfo }: ITalkPage) => {
   // 메모 init
   useEffect(() => {
     if (!viewMemo.length && tags.length >= 2) {
-      // 오류를 막기 위한 조건문
       fbMemo.initLastMemo(); // 불러왔던 마지막 메모 초기화
       doGetMemo(viewMemo, setViewMemo);
     }
@@ -115,6 +114,7 @@ const TalkPage = ({ fbMemo, fbTag, fbAuth, tags, userInfo }: ITalkPage) => {
       }
     });
   };
+
   // 무한스크롤 useEffect
   useEffect(() => {
     if (!topRef.current || !talkBoxRef.current) return;


### PR DESCRIPTION
- 메모 불러오기 오류
DB의 Tag가 삭제되지 않은 항목이 남아있어, 해당 Tag를 불러오는데에 생긴 오류
Tag가 없는 Memo 항목 두개 삭제
추후 동일한 오류가 발생하는지 주시

- 로드메모 갯수 수정
한번에 로드되는 메모 갯수 50 -> 30로 줄임
리소스 관리차원에서 축소